### PR TITLE
Add toggle for thicker staff lines

### DIFF
--- a/site/public/css/app.css
+++ b/site/public/css/app.css
@@ -787,6 +787,36 @@ div:has(> .file-dropdown__item) {
   margin-right: 0.5rem;
 }
 
+.thicker-staff-lines-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.thicker-staff-lines-toggle input[type="checkbox"][disabled] + span {
+  color: var(--mb-gray-50);
+}
+
+/* 15-note treble */
+.box-type-15.thicker-staff-lines #E4::before,
+.box-type-15.thicker-staff-lines #G4::before,
+.box-type-15.thicker-staff-lines #B4::before,
+.box-type-15.thicker-staff-lines #D5::before,
+.box-type-15.thicker-staff-lines #F5::before,
+/* 20-note bass */
+.box-type-20.thicker-staff-lines #D4::before,
+.box-type-20.thicker-staff-lines #F4::before,
+.box-type-20.thicker-staff-lines #A4::before,
+/* 20-note treble */
+.box-type-20.thicker-staff-lines #E5::before,
+.box-type-20.thicker-staff-lines #G5::before,
+.box-type-20.thicker-staff-lines #B5::before,
+.box-type-20.thicker-staff-lines #D6::before,
+.box-type-20.thicker-staff-lines #F6::before {
+  border-left-width: 3px;
+}
+
+
 .footnote p {
   font-size: 12px;
   margin: 0;

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -342,6 +342,12 @@
               </select>
             </label>
           </div>
+          <div id="thicker-staff-lines-toggle">
+            <label class="thicker-staff-lines-toggle">
+              <input class="thicker-staff-lines-toggle__checkbox" type="checkbox" name="thicker-staff-lines" />
+              <span>Thicker staff lines</span>
+            </label>
+          </div>
         </div>
       </div>
       <div id="footnote"></div>

--- a/site/public/js/app-entry.js
+++ b/site/public/js/app-entry.js
@@ -9,6 +9,7 @@ import { FileDropdown } from './components/file-dropdown.js';
 import { MusicBoxTypeSelect } from './components/music-box-type-select.js';
 import { Tempo } from './components/tempo.js';
 import { SnapToGridSelect } from './components/snap-to-grid-select.js';
+import { ThickerStaffLinesToggle } from './components/thicker-staff-lines-toggle.js';
 import { Footnote } from './components/footnote.js';
 import { SongTitle } from './components/song-title.js';
 import { PitchHeader } from './components/pitch-header.js';
@@ -40,6 +41,7 @@ import { urlManager } from './subscribers/url-manager.js';
 import { audioPlayer } from './subscribers/audio-player.js';
 import { songPauser } from './subscribers/song-pauser.js';
 import { setupTextSelectionListener } from './subscribers/text-selection-listener.js';
+import { loadLocalPreferences, subscribeLocalPreferencesToState } from './subscribers/local-preferences.js';
 
 import { setupTestObjects } from './test.js';
 
@@ -52,6 +54,9 @@ urlManager.getStateFromUrlAsync().then(urlState => {
   if (urlState) {
     musicBoxStore.state.songState = urlState;
   }
+
+  loadLocalPreferences();
+  subscribeLocalPreferencesToState();
 
   // Things we should set up before rendering components.
   playheadObserver.setup(); // because we observe new notes as they are created.
@@ -68,6 +73,7 @@ urlManager.getStateFromUrlAsync().then(urlState => {
   new MusicBoxTypeSelect().render();
   new Tempo().render();
   new SnapToGridSelect().render();
+  new ThickerStaffLinesToggle().render();
   new Footnote().render();
   new SongTitle().render();
   new PitchHeader().render();

--- a/site/public/js/components/body-class.js
+++ b/site/public/js/components/body-class.js
@@ -6,7 +6,7 @@ import classNames from '../vendor/classnames.js';
 export class BodyClass extends MBComponent {
   constructor() {
     super({
-      renderTrigger: ['appState.isPlaying', 'appState.offCanvasSidebarFocused', 'songState.songData'],
+      renderTrigger: ['appState.isPlaying', 'appState.offCanvasSidebarFocused', 'songState.songData', 'appState.thickerStaffLines'],
       element: document.body
     });
 
@@ -19,9 +19,13 @@ export class BodyClass extends MBComponent {
 
   // Limit render changes to body-class updates, so we don't need to rebuild internal components.
   render() {
+    const currentBoxType = getCurrentBoxType();
+    const paperCanHaveStaffLines = ['15', '20'].includes(currentBoxType)
+
     this.element.className = classNames(
-      `box-type-${getCurrentBoxType()}`,
+      `box-type-${currentBoxType}`,
       {
+        'thicker-staff-lines': musicBoxStore.state.appState.thickerStaffLines === true && paperCanHaveStaffLines,
         'no-focus': this.state.lastInputType === 'mouse',
         'no-scroll': musicBoxStore.state.appState.isPlaying === true ||
           musicBoxStore.state.appState.offCanvasSidebarFocused !== 'none'

--- a/site/public/js/components/thicker-staff-lines-toggle.js
+++ b/site/public/js/components/thicker-staff-lines-toggle.js
@@ -1,0 +1,42 @@
+import { MBComponent } from './music-box-component.js';
+import { musicBoxStore } from '../music-box-store.js';
+import { getCurrentBoxType } from '../common/box-types.js';
+
+export class ThickerStaffLinesToggle extends MBComponent {
+  constructor() {
+    super({
+      element: document.querySelector('#thicker-staff-lines-toggle'),
+      renderTrigger: ['appState.thickerStaffLines', 'songState.songData'],
+    });
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(event) {
+    const currentBoxType = getCurrentBoxType();
+
+    musicBoxStore.setState('appState.thickerStaffLines', event.target.checked);
+  }
+
+  render() {
+    const currentBoxType = getCurrentBoxType();
+    const isDisabled = !['15', '20'].includes(currentBoxType);
+    const checked = musicBoxStore.state.appState.thickerStaffLines === true ? 'checked' : '';
+    const disabled = isDisabled ? 'disabled' : '';
+
+    this.element.innerHTML = `
+      <label class="thicker-staff-lines-toggle">
+        <input
+          class="thicker-staff-lines-toggle__checkbox"
+          type="checkbox"
+          name="thicker-staff-lines"
+          ${checked}
+          ${disabled}
+        />
+        <span>Thicker staff lines</span>
+      </label>
+    `;
+
+    this.element.querySelector('input[type="checkbox"]').addEventListener('change', this.handleChange);
+  }
+}

--- a/site/public/js/state.js
+++ b/site/public/js/state.js
@@ -8,6 +8,7 @@ import { DEFAULT_TEMPO } from './constants.js';
 export const initialState = {
   appState: {
     snapTo: 'grid',
+    thickerStaffLines: false,
     isPlaying: false,
     audioDisabledMessageStatus: 'hidden',
     offCanvasSidebarFocused: 'none',

--- a/site/public/js/subscribers/local-preferences.js
+++ b/site/public/js/subscribers/local-preferences.js
@@ -1,0 +1,31 @@
+import { musicBoxStore } from '../music-box-store.js';
+
+const THICKER_STAFF_LINES_KEY = 'musicboxfun:thickerStaffLines';
+
+export function loadLocalPreferences() {
+  try {
+    const storedValue = window.localStorage.getItem(THICKER_STAFF_LINES_KEY);
+
+    if (storedValue === null) return;
+
+    musicBoxStore.state.appState.thickerStaffLines = storedValue === 'true';
+  } catch (error) {
+    // localStorage can throw errors in some browsers/privacy modes
+  }
+}
+
+export function subscribeLocalPreferencesToState() {
+  const persistThickerStaffLines = () => {
+    try {
+      window.localStorage.setItem(
+        THICKER_STAFF_LINES_KEY,
+        String(musicBoxStore.state.appState.thickerStaffLines === true)
+      );
+    } catch (error) {
+      // localStorage can throw errors in some browsers/privacy modes
+    }
+  };
+
+  persistThickerStaffLines.id = 'persistThickerStaffLines';
+  musicBoxStore.subscribe('appState.thickerStaffLines', persistThickerStaffLines);
+}


### PR DESCRIPTION
The toggle is only enabled for 15/20 note paper
where it is commonly printed.

Persist the checkbox state in local storage, as it
is an editor preference, not a publishing preference.

Fixes #33
